### PR TITLE
Add README auth section

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ Static assets live under `public/assets/`. Additional folders such as `scenes/`,
 
 See `public/.well-known/openapi.json` for the minimal API specification.
 
+## Authentication
+
+Authentication routes require the environment variables described in `.env` to be configured. Set your session secrets and OAuth provider details before using them.
+
+- `POST /register` – register a new username and password.
+- `GET /login` – start the OAuth2 flow and redirect to the provider.
+- `GET /oauth/callback` – handle the provider's response and set a `token` cookie.
+- `GET /check_auth` – verify the current login state, returns `{ ok: true }` when authenticated.
+- **Log out** – clear the `token` cookie in your browser to remove the session.
+
 ## License
 
 Released under the MIT License. See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary
- document environment variables for login
- describe register, login, callback, status, and logout steps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868ca3824d4832fb7e2ae5bb651ef53