### PR TITLE
Update manifest URLs to localhost

### DIFF
--- a/public/.well-known/anthropic-manifest.json
+++ b/public/.well-known/anthropic-manifest.json
@@ -10,9 +10,9 @@
   },
   "api": {
     "type": "openapi",
-    "url": "https://example.com/.well-known/openapi.json"
+    "url": "http://localhost:3000/.well-known/openapi.json"
   },
   "logo_url": "/assets/icon.png",
   "contact_email": "admin@example.com",
-  "legal_info_url": "https://example.com/legal"
+  "legal_info_url": "http://localhost:3000/legal"
 }

--- a/public/.well-known/openapi.json
+++ b/public/.well-known/openapi.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://example.com"
+      "url": "http://localhost:3000"
     },
     {
       "url": "http://localhost:3000"


### PR DESCRIPTION
## Summary
- update Anthropic manifest to reference localhost
- update OpenAPI server URL to localhost

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868cad1d3e4832f8af8e6b0cfe2efa4

## Summary by Sourcery

Update manifest endpoints to use localhost for local development

Enhancements:
- Point Anthropic manifest server URL to localhost
- Point OpenAPI server URL to localhost