### PR TITLE
Fix syntax error in logout route

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -75,7 +75,6 @@ router.post('/logout', (req, res, next) => {
     res.json({ ok: true });
   });
 })
-})
 
 // Auth status check
 


### PR DESCRIPTION
## Summary
- remove stray closing token from logout endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868d931d10c832f87154866035d3d1e

## Summary by Sourcery

Bug Fixes:
- Remove stray closing bracket from the logout endpoint to resolve syntax error