### PR TITLE
Support multiple OAuth providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,17 @@ OAUTH_TOKEN_URL=
 # Set these if enabling OAuth2 login
 
 OAUTH_CALLBACK_URL=http://localhost:3000/oauth/callback
+
+# GitHub OAuth settings
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+GITHUB_AUTH_URL=
+GITHUB_TOKEN_URL=
+GITHUB_CALLBACK_URL=https://elriel-mcp-conclave.onrender.com/oauth/github/callback
+
+# Google OAuth settings
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_AUTH_URL=
+GOOGLE_TOKEN_URL=
+GOOGLE_CALLBACK_URL=https://elriel-mcp-conclave.onrender.com/oauth/google/callback

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The server defaults to port `3000`. You may set the `PORT` environment variable 
 
 Before running the server, copy `.env.example` to `.env` and provide values for
 `SESSION_SECRET` and `JWT_SECRET`. If you plan to use OAuth2 login, also fill in
-the `OAUTH_*` variables with your provider details:
+the provider variables with your details:
 
 ```bash
 cp .env.example .env
@@ -36,6 +36,16 @@ cp .env.example .env
 # OAUTH_AUTH_URL=https://provider.com/oauth/authorize
 # OAUTH_TOKEN_URL=https://provider.com/oauth/token
 # OAUTH_CALLBACK_URL=http://localhost:3000/oauth/callback
+# GITHUB_CLIENT_ID=...
+# GITHUB_CLIENT_SECRET=...
+# GITHUB_AUTH_URL=...
+# GITHUB_TOKEN_URL=...
+# GITHUB_CALLBACK_URL=https://elriel-mcp-conclave.onrender.com/oauth/github/callback
+# GOOGLE_CLIENT_ID=...
+# GOOGLE_CLIENT_SECRET=...
+# GOOGLE_AUTH_URL=...
+# GOOGLE_TOKEN_URL=...
+# GOOGLE_CALLBACK_URL=https://elriel-mcp-conclave.onrender.com/oauth/google/callback
 ```
 
 ## Usage
@@ -64,8 +74,12 @@ See `public/.well-known/openapi.json` for the minimal API specification.
 Authentication routes require the environment variables described in `.env` to be configured. Set your session secrets and OAuth provider details before using them.
 
 - `POST /register` – register a new username and password.
-- `GET /login` – start the OAuth2 flow and redirect to the provider.
-- `GET /oauth/callback` – handle the provider's response and set a `token` cookie.
+- `GET /login` – start the generic OAuth2 flow when `OAUTH_*` variables are configured.
+- `GET /login/github` – begin the GitHub OAuth process when GitHub variables are present.
+- `GET /login/google` – begin the Google OAuth process when Google variables are present.
+- `GET /oauth/callback` – handle the generic provider response.
+- `GET /oauth/github/callback` – GitHub OAuth callback.
+- `GET /oauth/google/callback` – Google OAuth callback.
 - `GET /check_auth` – verify the current login state, returns `{ ok: true }` when authenticated.
 - **Log out** – clear the `token` cookie in your browser to remove the session.
 

--- a/public/.well-known/openapi.json
+++ b/public/.well-known/openapi.json
@@ -125,6 +125,46 @@
         }
       }
     },
+    "/login/github": {
+      "get": {
+        "summary": "Begin GitHub OAuth2 login",
+        "responses": {
+          "302": {
+            "description": "Redirect"
+          }
+        }
+      }
+    },
+    "/oauth/github/callback": {
+      "get": {
+        "summary": "GitHub OAuth2 callback",
+        "responses": {
+          "302": {
+            "description": "Redirect"
+          }
+        }
+      }
+    },
+    "/login/google": {
+      "get": {
+        "summary": "Begin Google OAuth2 login",
+        "responses": {
+          "302": {
+            "description": "Redirect"
+          }
+        }
+      }
+    },
+    "/oauth/google/callback": {
+      "get": {
+        "summary": "Google OAuth2 callback",
+        "responses": {
+          "302": {
+            "description": "Redirect"
+          }
+        }
+      }
+    },
     "/check_auth": {
       "get": {
         "summary": "Check authentication status",


### PR DESCRIPTION
## Summary
- add GitHub/Google env vars to `.env.example`
- document provider variables and login routes in README
- enable conditional Passport strategies for GitHub and Google
- expose new login endpoints in OpenAPI spec

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869cd982a48832fa6fdf95d7c40ab1e

## Summary by Sourcery

Enable multiple configurable OAuth providers (generic OAuth2, GitHub, and Google) by centralizing route registration, adding provider-specific environment variables, and updating documentation and API specs.

New Features:
- Add GitHub and Google OAuth login flows alongside existing generic OAuth2 support

Enhancements:
- Extract common logic into a registerProvider function to DRY up OAuth route registration
- Conditionally register OAuth endpoints based on environment variable presence for each provider

Documentation:
- Update README and .env.example with GitHub and Google environment variables and usage instructions
- Expose new `/login/github`, `/login/google`, and corresponding callback paths in the OpenAPI specification